### PR TITLE
Add base black and isort configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Some more details on the status quo and motivation for standardization are captu
 Currently other repositories will need to be manually synchronized
 with this one, in the future we may pursue some form of automation.
 
+## Tools
+The following tools are currently configured by this repository:
+* [black](https://black.readthedocs.io/en/stable/)
+* [isort](https://pycqa.github.io/isort/)
+
 ## License
 This repository is dual-licensed under the GPL-3.0-or-later and AGPL-3.0-or-later
 licenses, as the purpose is for things to be copied to SecureDrop repositories.

--- a/src/Makefile
+++ b/src/Makefile
@@ -29,7 +29,6 @@ check-isort: ## Check Python import organization with isort
 # 6. Format columns with colon as delimiter.
 .PHONY: help
 help: ## Print this message and exit.
-	@printf "Makefile for developing and testing the SecureDrop proxy.\n"
 	@printf "Subcommands:\n\n"
 	@awk 'BEGIN {FS = ":.*?## "} /^[0-9a-zA-Z_-]+:.*?## / {printf "\033[36m%s\033[0m : %s\n", $$1, $$2}' $(MAKEFILE_LIST) \
 		| sort \

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,19 +5,19 @@ all: help
 lint: check-isort check-black ## Run all linters and formatters
 
 .PHONY: black
-black: ## Check Python source code formatting with black
+black: ## Update Python source code formatting with black
 	@black .
 
 .PHONY: check-black
-check-black: ## Update Python source code formatting with black
+check-black: ## Check Python source code formatting with black
 	@black --check --diff .
 
 .PHONY: isort
-isort: ## Check Python import organization with isort
+isort: ## Update Python import organization with isort
 	@isort .
 
 .PHONY: check-isort
-check-isort: ## Update Python import organization with isort
+check-isort: ## Check Python import organization with isort
 	@isort --check-only --diff .
 
 # Explanation of the below shell command should it ever break.

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,36 @@
+.PHONY: all
+all: help
+
+.PHONY: lint
+lint: check-isort check-black ## Run all linters and formatters
+
+.PHONY: black
+black: ## Check Python source code formatting with black
+	@black .
+
+.PHONY: check-black
+check-black: ## Update Python source code formatting with black
+	@black --check --diff .
+
+.PHONY: isort
+isort: ## Check Python import organization with isort
+	@isort .
+
+.PHONY: check-isort
+check-isort: ## Update Python import organization with isort
+	@isort --check-only --diff .
+
+# Explanation of the below shell command should it ever break.
+# 1. Set the field separator to ": ##" and any make targets that might appear between : and ##
+# 2. Use sed-like syntax to remove the make targets
+# 3. Format the split fields into $$1) the target name (in blue) and $$2) the target descrption
+# 4. Pass this file as an arg to awk
+# 5. Sort it alphabetically
+# 6. Format columns with colon as delimiter.
+.PHONY: help
+help: ## Print this message and exit.
+	@printf "Makefile for developing and testing the SecureDrop proxy.\n"
+	@printf "Subcommands:\n\n"
+	@awk 'BEGIN {FS = ":.*?## "} /^[0-9a-zA-Z_-]+:.*?## / {printf "\033[36m%s\033[0m : %s\n", $$1, $$2}' $(MAKEFILE_LIST) \
+		| sort \
+		| column -s ':' -t

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@
 all: help
 
 .PHONY: lint
-lint: check-isort check-black ## Run all linters and formatters
+lint: check-isort check-black ## Check all linters and formatters (no changes will be made)
 
 .PHONY: black
 black: ## Update Python source code formatting with black

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+line-length = 100
+# Adjust to the lowest Python version we need to support
+target-version = ["py38"]
+extend-exclude = ".venv"
+
+[tool.isort]
+line_length = 100
+profile = "black"


### PR DESCRIPTION
black and isort are effectively a pair, both do code (re)formatting.

This defines the following Makefile entrypoints:
* black: Reformat code with black
* check-black: Check if code has been reformatted
* isort: Reorganize imports with isort
* check-isort: Check if code has been reorganized

Additionally it adds the base "lint" entrypoint which eventually will run all linters like flake8, mypy, etc.

The pyproject.toml configuration is largely based on <https://github.com/freedomofpress/securedrop/pull/6722>, which moved configuration out of the Makefile. Linting everything instead of specific folders will make it much easier to copy around to other repositories and reduce variance.