### PR TITLE
Add dependabot configuration for Poetry-enabled repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ The following tools are currently configured by this repository:
 * [black](https://black.readthedocs.io/en/stable/)
 * [isort](https://pycqa.github.io/isort/)
 
+## Services
+The following services are currently configured by this repository:
+* [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts)
+
 ## License
 This repository is dual-licensed under the GPL-3.0-or-later and AGPL-3.0-or-later
 licenses, as the purpose is for things to be copied to SecureDrop repositories.

--- a/src/.github/dependabot.yml
+++ b/src/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
This was developed and tested in the securedrop-dev-docs repository where dependabot successfully sent pull requests.

## Checklist
* [x] Documentation on how to review these changes: https://github.com/freedomofpress/securedrop-dev-docs/pull/52