### PR TITLE
Weekly commit to prevent actions from being disabled

### DIFF
--- a/.github/workflows/eol.yml
+++ b/.github/workflows/eol.yml
@@ -46,7 +46,17 @@ jobs:
         run: |
           git add eol-check/eol.ics
           if git diff --staged --quiet; then
-            echo "No calendar changes; skip commit."
+            echo "No calendar changes"
+
+            # Weekly commit to avoid going stale
+            if git log -1 --format=%cr | grep -Eq '(week(s)?|month(s)?|year(s)?) ago'; then
+              git commit --allow-empty  -m "chore: bump to avoid going stale" -m "Otherwise actions would be disabled (see issue #36)"
+              git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+              git push
+            else
+              echo "skipping commit"
+            fi
+
           else
             git commit -m "chore: update EOL calendar"
             git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git


### PR DESCRIPTION
Github actions get disabled on repos without activity for 60 days. A weekly commit should keep this going.

Instead of adding a new  workflow with a weekly cadence, I opted to add some logic that checks if the last commit was done recently to keep the logic closer together. That workflow should run daily, so it should solve the problem. I have made it also detect if it has been months or years, just in the cadence is changed and the script needs to pick up again.

Fixes #36